### PR TITLE
Run Maven build for pull requests

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -6,6 +6,9 @@ name: Maven Package
 on:
   release:
     types: [created]
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -29,6 +32,7 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
+      if: github.event_name == 'release'
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- run workflow on PRs targeting `main`
- only publish packages when a release is created

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684581325ecc832eaac33b1e505e61ab