### PR TITLE
Expose MySQL on NodePort

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ Forwarding from 127.0.0.1:3306 -> 3306
 Forwarding from [::1]:3306 -> 3306
 ```
 
+If you prefer direct access without port forwarding, update `mysql-service.yaml`
+to use a `NodePort` service. The example in this repository exposes port `3306`
+on node port `30306`:
+
+```
+spec:
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+      nodePort: 30306
+```
+After applying the updated service you can connect using `<node-ip>:30306`.
+
 ![Image](https://github.com/user-attachments/assets/943d18d8-2cfc-478e-91ed-a7cd7b1dcf23)
 
 #### Docker Desktop

--- a/biometric-nbi/src/kubernetes/mysql-service.yaml
+++ b/biometric-nbi/src/kubernetes/mysql-service.yaml
@@ -7,11 +7,12 @@ metadata:
   name: mysql
   namespace: mysql
 spec:
+  type: NodePort
   # kubectl port-forward mysql-58b7767464-dgpf4 3306:3306
   ports:
   - protocol: TCP
     port: 3306
     targetPort: 3306
+    nodePort: 30306
   selector:
     app: mysql
-  clusterIP: None


### PR DESCRIPTION
## Summary
- expose MySQL service using a NodePort
- document direct access via NodePort

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c2cfbe318832eb3ac380f623a5a80